### PR TITLE
Update standard gems and require standard-custom

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ inherit_mode:
 
 require:
   - standard
+  - standard-custom
+  - standard-performance
   - rubocop-performance
   - rubocop-rspec
 

--- a/.rubocop/custom.yml
+++ b/.rubocop/custom.yml
@@ -53,5 +53,33 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-  
-
+Capybara/MatchStyle: # new in 2.17
+  Enabled: true
+FactoryBot/AssociationStyle: # new in 2.23
+  Enabled: true
+FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
+  Enabled: true
+FactoryBot/FactoryNameStyle: # new in 2.16
+  Enabled: true
+FactoryBot/RedundantFactoryOption: # new in 2.23
+  Enabled: true
+RSpec/BeEmpty: # new in 2.20
+  Enabled: true
+RSpec/ContainExactly: # new in 2.19
+  Enabled: true
+RSpec/DuplicatedMetadata: # new in 2.16
+  Enabled: true
+RSpec/IndexedLet: # new in 2.20
+  Enabled: true
+RSpec/MatchArray: # new in 2.19
+  Enabled: true
+RSpec/PendingWithoutReason: # new in 2.16
+  Enabled: true
+RSpec/RedundantAround: # new in 2.19
+  Enabled: true
+RSpec/SkipBlockInsideExample: # new in 2.19
+  Enabled: true
+RSpec/Rails/MinitestAssertions: # new in 2.17
+  Enabled: true
+RSpec/Rails/TravelAround: # new in 2.19
+  Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,14 +106,15 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    standard (1.29.0)
+    standard (1.30.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.52.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.1.0)
-    standard-custom (1.0.1)
+    standard-custom (1.0.2)
       lint_roller (~> 1.0)
+      rubocop (~> 1.50)
     standard-performance (1.1.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.18.0)
@@ -138,7 +139,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop-rspec
   simplecov
-  standard (~> 1.29.0)
+  standard
   sul_orcid_client!
   vcr
   webmock

--- a/sul_orcid_client.gemspec
+++ b/sul_orcid_client.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "standard", "~> 1.29.0" # Pinning until https://github.com/standardrb/standard-custom/pull/5
+  spec.add_development_dependency "standard"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
# Why was this change made? 🤔

This commit updates the standard gems and uses the new pattern for requiring standardrb plugins in the `require` section of the rubocop configuration.

# How was this change tested? 🤨

CI
