### PR TITLE
Provide more info when 404 on update

### DIFF
--- a/lib/sul_orcid_client.rb
+++ b/lib/sul_orcid_client.rb
@@ -136,6 +136,8 @@ class SulOrcidClient
       work.merge({"put-code" => put_code}).to_json,
       "Content-Type" => "application/vnd.orcid+json")
 
+    raise "ORCID.org API returned #{response.status} when updating #{put_code} for #{orcidid}. The author may have previously deleted this work from their ORCID profile." if response.status == 404
+
     raise "ORCID.org API returned #{response.status} when updating #{put_code} for #{orcidid}" unless response.status == 200
     true
   end

--- a/spec/fixtures/vcr_cassettes/Sul_Orcid_Client/_update_work/raises_404.yml
+++ b/spec/fixtures/vcr_cassettes/Sul_Orcid_Client/_update_work/raises_404.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.sandbox.orcid.org/v3.0/0000-0003-3437-349X/work/12300000
+    body:
+      encoding: UTF-8
+      string: '{"title":{"title":{"value":"Twitter Makes It Worse: Political Journalists,
+        Gendered Echo Chambers, and the Amplification of Gender Bias"},"subtitle":null,"translated-title":null},"journal-title":{"value":"The
+        International Journal of Press/Politics"},"short-description":null,"citation":{"citation-type":"bibtex","citation-value":"@article{Usher_2018,\n\tdoi
+        = {10.1177/1940161218781254},\n\turl = {https://doi.org/10.1177%2F1940161218781254},\n\tyear
+        = 2018,\n\tmonth = {jun},\n\tpublisher = {{SAGE} Publications},\n\tvolume
+        = {23},\n\tnumber = {3},\n\tpages = {324--344},\n\tauthor = {Nikki Usher and
+        Jesse Holcomb and Justin Littman},\n\ttitle = {Twitter Makes It Worse: Political
+        Journalists, Gendered Echo Chambers, and the Amplification of Gender Bias},\n\tjournal
+        = {The International Journal of Press/Politics}\n}"},"type":"journal-article","publication-date":{"year":{"value":"2018"},"month":{"value":"07"},"day":{"value":"24"}},"external-ids":{"external-id":[{"external-id-type":"doi","external-id-value":"10.1177/1940161218781254","external-id-normalized":{"value":"10.1177/1940161218781254","transient":true},"external-id-normalized-error":null,"external-id-url":{"value":"https://doi.org/10.1177/1940161218781254"},"external-id-relationship":"self"}]},"url":{"value":"https://doi.org/10.1177/1940161218781254"},"contributors":{"contributor":[{"contributor-orcid":null,"credit-name":{"value":"Nikki
+        Usher"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Jesse
+        Holcomb"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}},{"contributor-orcid":null,"credit-name":{"value":"Justin
+        Littman"},"contributor-email":null,"contributor-attributes":{"contributor-sequence":null,"contributor-role":"author"}}]},"language-code":null,"country":null,"put-code":"12300000"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - stanford-library-sul-pub
+      Authorization:
+      - Bearer private_bearer_token
+      Content-Type:
+      - application/vnd.orcid+json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 25 Aug 2023 19:01:47 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7fc615edab172090-IAD
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Target:
+      - reg-sbox-mapi-use2-a1
+      X-Via:
+      - a1
+      X-Xss-Protection:
+      - 1; mode=block
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"response-code":404,"developer-message":"404 Not Found: The resource
+        was not found. Full validation error: No entity found for query","user-message":"The
+        resource was not found.","error-code":9016,"more-info":"https://members.orcid.org/api/resources/troubleshooting"}'
+  recorded_at: Fri, 25 Aug 2023 19:01:47 GMT
+recorded_with: VCR 6.2.0

--- a/spec/sul_orcid_client_spec.rb
+++ b/spec/sul_orcid_client_spec.rb
@@ -208,6 +208,14 @@ RSpec.describe SulOrcidClient do
       end
     end
 
+    context "when server returns a 404 error" do
+      it "raises with 404-specific message" do
+        VCR.use_cassette("Sul_Orcid_Client/_update_work/raises_404") do
+          expect { client.update_work(orcidid: "https://sandbox.orcid.org/0000-0003-3437-349X", put_code: "12300000", work:, token: "FAKE29cb-194e-4bc3-8afg-99315b06be0468cf29cb-294e-4bc8-8afd-96315b06ae04") }.to raise_error(StandardError, "ORCID.org API returned 404 when updating 12300000 for https://sandbox.orcid.org/0000-0003-3437-349X. The author may have previously deleted this work from their ORCID profile.")
+        end
+      end
+    end
+
     context "when server returns an error" do
       it "raises" do
         VCR.use_cassette("Sul_Orcid_Client/_update_work/raises") do


### PR DESCRIPTION
## Why was this change made? 🤔
To more easily identify cases when a user has deleted their work on an orcid profile and later updates it. (For example: https://app.honeybadger.io/projects/50568/faults/99675835)

## How was this change tested? 🤨
Unit
