### PR TITLE
deal with alternate orcid formats for contributors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/sul_orcid_client/cocina_support.rb
+++ b/lib/sul_orcid_client/cocina_support.rb
@@ -21,10 +21,7 @@ class SulOrcidClient
       return identifier.uri if identifier.uri
       return identifier.value if identifier.value.start_with?("https://orcid.org/")
 
-      # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
-      return URI.join("https://orcid.org/", identifier.value).to_s if identifier.source.uri.blank?
-
-      URI.join(identifier.source.uri, identifier.value).to_s
+      URI.join("https://orcid.org/", identifier.value).to_s
     end
 
     # @param [Cocina::Models::Description] description containing contributors to check

--- a/lib/sul_orcid_client/cocina_support.rb
+++ b/lib/sul_orcid_client/cocina_support.rb
@@ -17,6 +17,13 @@ class SulOrcidClient
       identifier = contributor.identifier.find { |identifier| identifier.type == "ORCID" }
       return unless identifier
 
+      # some records have the full ORCID URI in the data, just return it if so, e.g. druid:gf852zt8324
+      return identifier.uri if identifier.uri
+      return identifier.value if identifier.value.start_with?("https://orcid.org/")
+
+      # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
+      return URI.join("https://orcid.org/", identifier.value).to_s if identifier.source.uri.blank?
+
       URI.join(identifier.source.uri, identifier.value).to_s
     end
 

--- a/spec/sul_orcid_client/cocina_support_spec.rb
+++ b/spec/sul_orcid_client/cocina_support_spec.rb
@@ -86,6 +86,58 @@ RSpec.describe SulOrcidClient::CocinaSupport do
         expect(described_class.orcidid(contributor)).to eq("https://sandbox.orcid.org/0000-0003-3437-349X")
       end
     end
+
+    context "when alternate orcidid format" do
+      let(:contributor) do
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: "Justin Littman"
+            }
+          ],
+          type: "person",
+          identifier: [
+            {
+              value: "0000-0003-3437-349X",
+              type: "ORCID",
+              source: {
+                code: "orcid"
+              }
+            }
+          ]
+        )
+      end
+
+      it "returns the orcidid" do
+        expect(described_class.orcidid(contributor)).to eq("https://orcid.org/0000-0003-3437-349X")
+      end
+    end
+
+    context "when another alternate orcidid format" do
+      let(:contributor) do
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: "Justin Littman"
+            }
+          ],
+          type: "person",
+          identifier: [
+            {
+              uri: "https://orcid.org/0000-0003-3437-349X",
+              type: "ORCID",
+              source: {
+                code: "orcid"
+              }
+            }
+          ]
+        )
+      end
+
+      it "returns the orcidid" do
+        expect(described_class.orcidid(contributor)).to eq("https://orcid.org/0000-0003-3437-349X")
+      end
+    end
   end
 
   describe ".cited_orcidids" do

--- a/spec/sul_orcid_client/cocina_support_spec.rb
+++ b/spec/sul_orcid_client/cocina_support_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
               value: "0000-0003-3437-349X",
               type: "ORCID",
               source: {
-                uri: "https://sandbox.orcid.org"
+                uri: "https://orcid.org"
               }
             }
           ]
@@ -83,7 +83,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
       end
 
       it "returns the orcidid" do
-        expect(described_class.orcidid(contributor)).to eq("https://sandbox.orcid.org/0000-0003-3437-349X")
+        expect(described_class.orcidid(contributor)).to eq("https://orcid.org/0000-0003-3437-349X")
       end
     end
 
@@ -197,7 +197,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
     end
 
     it "returns the cited orcidids" do
-      expect(described_class.cited_orcidids(description)).to eq(["https://sandbox.orcid.org/0000-0003-3437-349X"])
+      expect(described_class.cited_orcidids(description)).to eq(["https://orcid.org/0000-0003-3437-349X"])
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Same thing as https://github.com/sul-dlss/dor_indexing_app/pull/1059.  We have varying formats of how ORCIDs are represented in contributors.  This deals with another case that caused https://app.honeybadger.io/projects/50568/faults/102209790  

Note: this also adds the other use case we added to dor_indexing_app here: https://github.com/sul-dlss/dor_indexing_app/pull/989 and https://github.com/sul-dlss/dor_indexing_app/pull/1001

We also needed to add to dor_indexing_app until we consolidate as described in https://github.com/sul-dlss/dor_indexing_app/issues/1022

## How was this change tested? 🤨

New specs