### PR TITLE
allow sandbox URIs in test data to be returned

### DIFF
--- a/lib/sul_orcid_client/cocina_support.rb
+++ b/lib/sul_orcid_client/cocina_support.rb
@@ -21,7 +21,10 @@ class SulOrcidClient
       return identifier.uri if identifier.uri
       return identifier.value if identifier.value.start_with?("https://orcid.org/")
 
-      URI.join("https://orcid.org/", identifier.value).to_s
+      # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
+      return URI.join("https://orcid.org/", identifier.value).to_s if identifier.source.uri.blank?
+
+      URI.join(identifier.source.uri, identifier.value).to_s
     end
 
     # @param [Cocina::Models::Description] description containing contributors to check

--- a/spec/sul_orcid_client/cocina_support_spec.rb
+++ b/spec/sul_orcid_client/cocina_support_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
               value: "0000-0003-3437-349X",
               type: "ORCID",
               source: {
-                uri: "https://orcid.org"
+                uri: "https://sandbox.orcid.org"
               }
             }
           ]
@@ -83,7 +83,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
       end
 
       it "returns the orcidid" do
-        expect(described_class.orcidid(contributor)).to eq("https://orcid.org/0000-0003-3437-349X")
+        expect(described_class.orcidid(contributor)).to eq("https://sandbox.orcid.org/0000-0003-3437-349X")
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
           type: "person",
           identifier: [
             {
-              uri: "https://orcid.org/0000-0003-3437-349X",
+              uri: "https://sandbox.orcid.org/0000-0003-3437-349X",
               type: "ORCID",
               source: {
                 code: "orcid"
@@ -135,7 +135,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
       end
 
       it "returns the orcidid" do
-        expect(described_class.orcidid(contributor)).to eq("https://orcid.org/0000-0003-3437-349X")
+        expect(described_class.orcidid(contributor)).to eq("https://sandbox.orcid.org/0000-0003-3437-349X")
       end
     end
   end
@@ -197,7 +197,7 @@ RSpec.describe SulOrcidClient::CocinaSupport do
     end
 
     it "returns the cited orcidids" do
-      expect(described_class.cited_orcidids(description)).to eq(["https://orcid.org/0000-0003-3437-349X"])
+      expect(described_class.cited_orcidids(description)).to eq(["https://sandbox.orcid.org/0000-0003-3437-349X"])
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Rolls back a change introduced in https://github.com/sul-dlss/orcid_client/pull/30/files that would replace any sandbox ORCID URIs in test data with production ORCID URIs.  This causes test failures in DSA (https://app.circleci.com/jobs/github/sul-dlss/dor-services-app/20467) and also would not allow for a fully connected test environment.

## How was this change tested? 🤨

Updated specs
