### PR TITLE
Loosen activesupport pin to allow Rails 8 upgrades

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sul_orcid_client (0.4.1)
-      activesupport (>= 4.2, < 8)
+      activesupport (>= 4.2)
       cocina-models (~> 0.90)
       faraday
       faraday-retry
@@ -12,7 +12,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.1)
+    activesupport (8.0.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -24,6 +24,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -101,7 +102,7 @@ GEM
     jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.4)
-    logger (1.6.5)
+    logger (1.6.6)
     minitest (5.25.4)
     multi_json (1.15.0)
     multi_xml (0.7.1)

--- a/sul_orcid_client.gemspec
+++ b/sul_orcid_client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 4.2', '< 8'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'cocina-models', '~> 0.90'
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday-retry'


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

