### PR TITLE
Do not send ROR identifier with organizational contributor.

### DIFF
--- a/lib/sul_orcid_client/contributor_mapper.rb
+++ b/lib/sul_orcid_client/contributor_mapper.rb
@@ -38,7 +38,6 @@ class SulOrcidClient
       }
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def name_from_structured_value(structured_value)
       forename = structured_value.find { |name_part| name_part.type == 'forename' }&.value
       surname = structured_value.find { |name_part| name_part.type == 'surname' }&.value
@@ -46,60 +45,20 @@ class SulOrcidClient
       if forename.present? || surname.present?
         [forename, surname].compact.join(' ')
       else
-        # take first value for the Stanford University organization. Do not map the department/institute suborganization for now.
-        structured_value.first&.value
+        structured_value.first.value
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-    IDENTIFIER_TYPES = %w[ORCID ROR].freeze
-
+    # find and map an ORCID from a contributor.identifier
     def map_orcid
-      if contributor.name.first&.structuredValue.present?
-        # there could be an identifier in the structuredValue if it has a suborganization
-        if contributor.name.first.structuredValue.first&.identifier.present?
-          orcid_from_structured_value
-        else
-          orcid_from_contributor
-        end
-      else
-        orcid_from_contributor
-      end
-    end
+      identifier = contributor.identifier.find { |check_identifier| check_identifier.type == 'ORCID' }
+      return unless identifier
 
-    def identifier_from_structured_value(structured_value)
-      structured_value.identifier.find { |identifier| IDENTIFIER_TYPES.include?(identifier.type) }
-    end
-
-    # the identifier in the structuredValue has the uri in a different properties than a top-level contributor.identifier
-    def map_orcid_from_structured_value(identifier)
-      {
-        uri: identifier.uri || identifier.value,
-        path: URI(identifier.uri).path.split('/').last,
-        host: identifier.type == 'ORCID' ? 'orcid.org' : 'ror.org'
-      }
-    end
-
-    def map_orcid_from_contributor(identifier)
       {
         uri: URI.join(identifier.source.uri, identifier.value).to_s,
         path: identifier.value,
-        host: identifier.type == 'ORCID' ? 'orcid.org' : 'ror.org'
+        host: 'orcid.org'
       }
-    end
-
-    # find and map an orcid from a contributor.identifier
-    def orcid_from_contributor
-      identifier = contributor.identifier.find { |check_identifier| IDENTIFIER_TYPES.include?(check_identifier.type) }
-      return unless identifier
-
-      map_orcid_from_contributor(identifier)
-    end
-
-    # find and map an orcid from a contributor.structuredValue.identifier
-    def orcid_from_structured_value
-      identifier = identifier_from_structured_value(contributor.name.first.structuredValue.first)
-      map_orcid_from_structured_value(identifier)
     end
 
     def map_attributes

--- a/spec/sul_orcid_client/contributor_mapper_spec.rb
+++ b/spec/sul_orcid_client/contributor_mapper_spec.rb
@@ -133,11 +133,6 @@ RSpec.describe SulOrcidClient::ContributorMapper do
         {
           'credit-name': {
             value: 'Stanford University'
-          },
-          'contributor-orcid': {
-            uri: 'https://ror.org/00f54p054',
-            path: '00f54p054',
-            host: 'ror.org'
           }
         }
       )
@@ -190,11 +185,6 @@ RSpec.describe SulOrcidClient::ContributorMapper do
         {
           'credit-name': {
             value: 'Stanford University'
-          },
-          'contributor-orcid': {
-            uri: 'https://ror.org/00f54p054',
-            path: '00f54p054',
-            host: 'ror.org'
           }
         }
       )


### PR DESCRIPTION
## Why was this change made? 🤔
H3 can add RORs to organizational contributors and orcid_client was including them in the metadata sent to ORCID. Based on @amyehodge's research, it doesn't appear that ORCID wants/uses these. Including one in a `contributor-orcid` property for an organization will return a 400 error: https://app.honeybadger.io/projects/50568/faults/121868674

This PR changes the contributor mapping to no longer accept RORs as an identifier. 

## How was this change tested? 🤨
Unit. 
