### PR TITLE
Support mapping structured titles in work mapper

### DIFF
--- a/lib/sul_orcid_client/work_mapper.rb
+++ b/lib/sul_orcid_client/work_mapper.rb
@@ -44,7 +44,7 @@ class SulOrcidClient
     attr_reader :description, :doi
 
     def map_title
-      title = description.title.first&.value
+      title = simple_title.presence || structured_title
       raise WorkMapperError, 'Title not mapped' unless title
 
       {
@@ -52,6 +52,20 @@ class SulOrcidClient
           value: title.truncate(500) # ORCID has a max length for this field
         }
       }
+    end
+
+    def simple_title
+      first_title&.value
+    end
+
+    def structured_title
+      return if first_title.structuredValue.blank?
+
+      first_title.structuredValue.find { |sv| sv.type == 'main title' }&.value
+    end
+
+    def first_title
+      description.title.first
     end
 
     def map_short_description

--- a/spec/sul_orcid_client/work_mapper_spec.rb
+++ b/spec/sul_orcid_client/work_mapper_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe SulOrcidClient::WorkMapper do
       end
     end
 
-    context 'when no title' do
+    context 'with a structured title' do
       let(:description) do
         Cocina::Models::Description.new(
           title: [
@@ -232,10 +232,30 @@ RSpec.describe SulOrcidClient::WorkMapper do
         )
       end
 
-      it 'raises' do
-        expect do
-          described_class.map(description:)
-        end.to raise_error(SulOrcidClient::WorkMapper::WorkMapperError)
+      let(:work) do
+        described_class.map(description:)
+      end
+
+      it 'maps' do
+        expect(work).to eq(
+          country: { value: 'US' },
+          'external-ids': {
+            'external-id': [
+              {
+                'external-id-relationship': 'self',
+                'external-id-type': 'uri',
+                'external-id-url': {
+                  value: 'https://purl.stanford.edu/hj302gv2126'
+                },
+                'external-id-value': 'https://purl.stanford.edu/hj302gv2126'
+              }
+            ]
+          },
+          'language-code': 'en',
+          title: { title: { value: 'code4lib journal' } },
+          type: 'other',
+          url: 'https://purl.stanford.edu/hj302gv2126'
+        )
       end
     end
   end


### PR DESCRIPTION
This was discovered to be needed for ETDs.

See https://app.honeybadger.io/projects/50568/faults/123837120